### PR TITLE
Broken makefile correction

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 all: clean readMsg writeMsg
 
 readMsg: stego.c readMsg.c
-	$(CC) -o ReadMsg stego.c ReadMsg.c
+	$(CC) -o readMsg stego.c readMsg.c
 
 writeMsg: stego.c writeMsg.c
 	$(CC) -o writeMsg stego.c writeMsg.c


### PR DESCRIPTION
Makefile contained some typo errors that rendered compilation impossible.
